### PR TITLE
fix calculate cost fxn, consolidate constants, add usage examples to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-TokenCost is a specialized tool designed for calculating the token count and associated cost of strings and messages used in Large Language Models (LLMs). This utility is particularly useful for developers and researchers working with language models, enabling them to estimate the computational resources required for processing various inputs.
+TokenCost is a specialized tool designed for calculating the token count and associated U.S. dollar cost of strings and messages used in Large Language Models (LLMs). This utility is particularly useful for developers and researchers working with language models, enabling them to estimate the computational resources required for processing various inputs and their returned outputs.
 
 ## Features
 
@@ -35,19 +35,50 @@ To use TokenCost, follow these steps:
 
 1. Import the module:
 
+- If you want to call the functions as `function_name` directly:
 ```python
-from tokencost import TokenCalculator
+from tokencost import *
 ```
 
 
-3. Calculate tokens and cost:
+- OR if you want to call the functions as `tokencost.function_name`:
 ```python
-text = "Your sample text here"
-token_count, cost = calculator.calculate(text)
-print(f"Token Count: {token_count}, Cost: {cost}")
+import tokencost
 ```
 
-### Running tests
+2. Calculate tokens and cost (using `from tokencost import *`):
+```python
+prompt = "Your sample text here"
+response = "Sample response text"
+model= "gpt-3.5-turbo"
+
+prompt_token_count = count_string_tokens(prompt, model)
+completion_token_count = count_string_tokens(response, model)
+cost = calculate_cost(prompt, response, model)
+
+print(f"Prompt Token Count: {prompt_token_count}, Completion Token Count: {completion_token_count}, Cost: ${cost/USD_PER_TPU} ({cost/CENTS_PER_TPU} cents)")
+```
+
+This is what it should look like when you use iPython:
+```bash
+In [1]: from tokencost import *
+
+In [2]: prompt = "Your sample text here"
+   ...: response = "Sample response text"
+   ...: model= "gpt-3.5-turbo"
+   ...: prompt_token_count = count_string_tokens(prompt, model)
+   ...: completion_token_count =count_string_tokens(response, model)
+   ...: cost = calculate_cost(prompt, response, model)
+   ...:
+   ...:
+   ...: print(f"Prompt Token Count: {prompt_token_count}, Completion Token Count: {c
+   ...: ompletion_token_count}, Cost: ${cost/USD_PER_TPU} ({cost/CENTS_PER_TPU} cent
+   ...: s)")
+Prompt Token Count: 4, Completion Token Count: 3, Cost: $1.2e-05 (0.0012 cents)
+```
+
+
+## Running tests
 0. Install ```pytest``` if you don't have it already
 ```python
 pip install pytest
@@ -60,7 +91,7 @@ pytest tests
 
 ## Contributing
 
-Contributions to TokenCost are welcome! Please refer to our Contribution Guidelines for more details.
+Contributions to TokenCost are welcome! Feel free to create an [issue](https://github.com/AgentOps-AI/tokencost/issues) for any bug reports, complaints, or feature suggestions.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -48,15 +48,41 @@ import tokencost
 
 2. Calculate tokens and cost (using `from tokencost import *`):
 ```python
-prompt = "Your sample text here"
+
+
+string_prompt = "Your sample text here"
 response = "Sample response text"
 model= "gpt-3.5-turbo"
 
-prompt_token_count = count_string_tokens(prompt, model)
-completion_token_count = count_string_tokens(response, model)
-cost = calculate_cost(prompt, response, model)
+string_cost = calculate_cost(string_prompt, response, model)
 
-print(f"Prompt Token Count: {prompt_token_count}, Completion Token Count: {completion_token_count}, Cost: ${cost/USD_PER_TPU} ({cost/CENTS_PER_TPU} cents)")
+prompt_string_token_count = count_string_tokens(string_prompt, model)
+
+print(f"Prompt Token Count: {prompt_string_token_count}, Completion Token Count:{completion_string_token_count}, Cost: ${string_cost/USD_PER_TPU} ({string_cost/CENTS_PER_TPU} cents)")
+
+messages =[
+    {
+        "role": "user",
+        "content": "Hey how is your day",
+    },
+    {
+        "role": 'assistant',
+        "content": "As an LLM model I do not have days"
+    },
+    {
+        "role": "user",
+        "content": "Err sure okay fine"
+    }
+]
+response = "Sample response text"
+model= "gpt-3.5-turbo"
+
+message_cost = calculate_cost(messages, response, model)
+
+prompt_message_token_count = count_message_tokens(messages, model)
+completion_string_token_count = count_string_tokens(response, model)
+
+print(f"Prompt Token Count: {prompt_message_token_count}, Completion Token Count: {completion_string_token_count}, Cost: ${message_cost/USD_PER_TPU} ({message_cost/CENTS_PER_TPU} cents)")
 ```
 
 This is what it should look like when you use iPython:

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -31,7 +31,7 @@ STRING = "Hello, world!"
     ("gpt-4-32k", 15),
     ("gpt-4-32k-0314", 15),
     ("gpt-4-1106-preview", 15),
-    ("gpt-4-1106-vision-preview", 15),
+    ("gpt-4-vision-preview", 15),
 ])
 def test_count_message_tokens(model, expected_output):
     print(model)
@@ -53,7 +53,7 @@ def test_count_message_tokens(model, expected_output):
     ("gpt-4-32k", 17),
     ("gpt-4-32k-0314", 17),
     ("gpt-4-1106-preview", 17),
-    ("gpt-4-1106-vision-preview", 17),
+    ("gpt-4-vision-preview", 17),
 ])
 def test_count_message_tokens_with_name(model, expected_output):
     """Notice: name 'John' appears"""
@@ -88,7 +88,7 @@ def test_count_message_tokens_invalid_model():
     ("gpt-4-32k-0314", 4),
     ("gpt-4-0613", 4),
     ("gpt-4-1106-preview", 4),
-    ("gpt-4-1106-vision-preview", 4),
+    ("gpt-4-vision-preview", 4),
     ("text-embedding-ada-002", 4),
 ])
 def test_count_string_tokens(model, expected_output):
@@ -110,7 +110,6 @@ def test_count_string_tokens_invalid_model():
 
 # Costs from https://openai.com/pricing
 # https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo
-
 @pytest.mark.parametrize("prompt,completion,model,expected_output", [
     (STRING, MESSAGES, "gpt-3.5-turbo", 360),
     (STRING, STRING, "gpt-3.5-turbo", 140),
@@ -129,7 +128,7 @@ def test_count_string_tokens_invalid_model():
     (STRING, STRING, "gpt-4-32k-0314", 7200),
     (STRING, STRING, "gpt-4-0613", 3600),
     (STRING, STRING, "gpt-4-1106-preview", 1600),
-    (STRING, STRING, "gpt-4-1106-vision-preview", 1600),
+    (STRING, STRING, "gpt-4-vision-preview", 1600),
     (STRING, STRING, "text-embedding-ada-002", 4),
 ])
 def test_calculate_cost(prompt, completion, model, expected_output):

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -14,9 +14,9 @@ MESSAGES_WITH_NAME = [
     {"role": "assistant", "content": "Hi there!"},
 ]
 
+STRING = "Hello, world!"
+
 # Chat models only, no embeddings (such as ada) since embeddings only does strings, not messages
-
-
 @pytest.mark.parametrize("model,expected_output", [
     ("gpt-3.5-turbo", 15),
     ("gpt-3.5-turbo-0301", 17),
@@ -110,44 +110,51 @@ def test_count_string_tokens_invalid_model():
 
 # Costs from https://openai.com/pricing
 # https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo
-@pytest.mark.parametrize("model,expected_output", [
-    ("gpt-3.5-turbo", 7500),
-    ("gpt-3.5-turbo-0301", 7500),
-    ("gpt-3.5-turbo-0613", 7500),
-    ("gpt-3.5-turbo-16k", 15000),
-    ("gpt-3.5-turbo-16k-0613", 15000),
-    ("gpt-3.5-turbo-1106", 6000),
-    ("gpt-3.5-turbo-instruct", 7500),
-    ("gpt-4", 180000),
-    ("gpt-4-0314", 180000),
-    ("gpt-4-32k", 360000),
-    ("gpt-4-32k-0314", 360000),
-    ("gpt-4-0613", 180000),
-    ("gpt-4-1106-preview", 75000),
-    ("gpt-4-1106-vision-preview", 75000),
-    ("text-embedding-ada-002", 300),
+
+@pytest.mark.parametrize("prompt,completion,model,expected_output", [
+    (STRING, MESSAGES, "gpt-3.5-turbo", 360),
+    (STRING, STRING, "gpt-3.5-turbo", 140),
+    (MESSAGES, STRING, "gpt-3.5-turbo", 305),
+    (MESSAGES, MESSAGES, "gpt-3.5-turbo", 525),
+    ([MESSAGES[0]], "", "gpt-3.5-turbo", 120),
+    (STRING, STRING, "gpt-3.5-turbo-0301", 140),
+    (STRING, STRING, "gpt-3.5-turbo-0613", 140),
+    (STRING, STRING, "gpt-3.5-turbo-16k", 280),
+    (STRING, STRING, "gpt-3.5-turbo-16k-0613", 280),
+    (STRING, STRING, "gpt-3.5-turbo-1106", 120),
+    (STRING, STRING, "gpt-3.5-turbo-instruct", 140),
+    (STRING, STRING, "gpt-4", 3600),
+    (STRING, STRING, "gpt-4-0314", 3600),
+    (STRING, STRING, "gpt-4-32k", 7200),
+    (STRING, STRING, "gpt-4-32k-0314", 7200),
+    (STRING, STRING, "gpt-4-0613", 3600),
+    (STRING, STRING, "gpt-4-1106-preview", 1600),
+    (STRING, STRING, "gpt-4-1106-vision-preview", 1600),
+    (STRING, STRING, "text-embedding-ada-002", 4),
 ])
-def test_calculate_cost(model, expected_output):
+def test_calculate_cost(prompt, completion, model, expected_output):
     """Test that the cost calculation is correct."""
 
-    prompt_tokens = count_string_tokens('hello world!'*100,  # 300 tokens
-                                        model)
-    assert prompt_tokens == 300
-    completion_tokens = count_string_tokens('hello world!'*50,  # 150 tokens
-                                            model)
-
-    assert completion_tokens == 150
-
-    cost = calculate_cost(prompt_tokens,
-                          completion_tokens,
+    cost = calculate_cost(prompt,
+                          completion,
                           model)
     assert cost == expected_output
-
-    assert calculate_cost(900, 754, 'gpt-4') == 722400
 
 
 def test_calculate_cost_invalid_model():
     """Invalid model should raise a KeyError"""
 
     with pytest.raises(KeyError):
-        calculate_cost(900, 754, model="invalid_model")
+        calculate_cost(STRING, STRING, model="invalid_model")
+
+def test_calculate_cost_invalid_input_types():
+    """Invalid input type should raise a KeyError"""
+
+    with pytest.raises(KeyError):
+        calculate_cost(5, STRING, model="invalid_model")
+
+    with pytest.raises(KeyError):
+        calculate_cost(STRING, 5, model="invalid_model")
+
+    with pytest.raises(KeyError):
+        calculate_cost(MESSAGES[0], 5, model="invalid_model") # Message objects not allowed, must be list of message objects.

--- a/tokencost/__init__.py
+++ b/tokencost/__init__.py
@@ -1,2 +1,2 @@
-from .costs import count_message_tokens, count_string_tokens, get_max_completion_tokens, calculate_cost
-from .constants import TOKEN_MAX, TOKEN_COSTS
+from .costs import count_message_tokens, count_string_tokens, calculate_cost
+from .constants import TOKEN_COSTS

--- a/tokencost/__init__.py
+++ b/tokencost/__init__.py
@@ -1,2 +1,2 @@
 from .costs import count_message_tokens, count_string_tokens, calculate_cost
-from .constants import TOKEN_COSTS
+from .constants import TOKEN_COSTS, USD_PER_TPU, CENTS_PER_TPU

--- a/tokencost/constants.py
+++ b/tokencost/constants.py
@@ -1,4 +1,5 @@
-# Last updated Dec 6 2023 from https://openai.com/pricing
+# Prices last updated Dec 6 2023 from https://openai.com/pricing
+# Max prompt limits last upated Dec 14 2023 by overloading the API and reading the error message.
 
 """
 Prompt tokens are based on number of words + other chars (eg spaces and punctuation) in input.
@@ -7,44 +8,30 @@ Completion tokens are similarly based on how long chatGPT's response is.
 You can use ChatGPT's webapp (which uses their tiktoken repo) to see how many tokens your phrase is:
 https://platform.openai.com/tokenizer
 
-However, when asking follow-up questions and to maintain context, everything above and
-including your follow-up question is considered a prompt and will cost prompt tokens.
+Note: When asking follow-up questions, everything above and including your follow-up question
+is considered a prompt (for the purpose of context) and will thus cost prompt tokens.
 """
 
+# 1 Token Price Unit (TPU) = 1/10,000,000 of $1 (USD). 100,000 TPUs would equate to $0.01.
 # How to read the below: Each prompt token costs __ TPUs per token, and each completion token costs __ TPUs per token.
-# Calculated in TPUs (token price unit), where 1 TPU = 1/10,000,000 of $1 (USD). 100,000 TPUs would equate to $0.01.
+# Max prompt token limit of each model is __. The max total limit is typically 1 more than the prompt token limit, so there's space for at least one completion token.
+
 TOKEN_COSTS = {
     # Applications using the gpt-3.5-turbo name will automatically be upgraded to the new model on December 11, 2023.
-    "gpt-3.5-turbo": {"prompt": 15, "completion": 20},
-    "gpt-3.5-turbo-0301": {"prompt": 15, "completion": 20},
-    "gpt-3.5-turbo-0613": {"prompt": 15, "completion": 20},
-    "gpt-3.5-turbo-16k": {"prompt": 30, "completion": 40},
-    "gpt-3.5-turbo-16k-0613": {"prompt": 30, "completion": 40},
-    "gpt-3.5-turbo-1106": {"prompt": 10, "completion": 20},
-    "gpt-3.5-turbo-instruct": {"prompt": 15, "completion": 20},
-    "gpt-4": {"prompt": 300, "completion": 600},
-    "gpt-4-0314": {"prompt": 300, "completion": 600},
-    "gpt-4-0613": {"prompt": 300, "completion": 600},
-    "gpt-4-32k": {"prompt": 600, "completion": 1200},
-    "gpt-4-32k-0314": {"prompt": 600, "completion": 1200},
-    "gpt-4-32k-0613": {"prompt": 600, "completion": 1200},
-    "gpt-4-1106-preview": {"prompt": 100, "completion": 300},
-    "gpt-4-1106-vision-preview": {"prompt": 100, "completion": 300},
-    "text-embedding-ada-002": {"prompt": 1, "completion": 0, },
-}
-
-# Token max is the combined prompt/completion limit.
-TOKEN_MAX = {
-    "gpt-3.5-turbo": 4096,
-    "gpt-3.5-turbo-0301": 4096,
-    "gpt-3.5-turbo-0613": 4096,
-    "gpt-3.5-turbo-16k": 16384,
-    "gpt-3.5-turbo-16k-0613": 16384,
-    "gpt-4": 8192,
-    "gpt-4-0314": 8192,
-    "gpt-4-32k": 32768,
-    "gpt-4-32k-0314": 32768,
-    "gpt-4-0613": 8192,
-    "gpt-4-1106-vision-preview": 4096,
-    "text-embedding-ada-002": 8192,
+    "gpt-3.5-turbo": {"prompt": 15, "completion": 20, "max_prompt": 4097},
+    "gpt-3.5-turbo-0301": {"prompt": 15, "completion": 20, "max_prompt": 4097},
+    "gpt-3.5-turbo-0613": {"prompt": 15, "completion": 20, "max_prompt": 4097},
+    "gpt-3.5-turbo-16k": {"prompt": 30, "completion": 40, "max_prompt": 16385},
+    "gpt-3.5-turbo-16k-0613": {"prompt": 30, "completion": 40, "max_prompt": 16385},
+    "gpt-3.5-turbo-1106": {"prompt": 10, "completion": 20, "max_prompt": 16385},
+    "gpt-3.5-turbo-instruct": {"prompt": 15, "completion": 20}, # Not a chat model error.
+    "gpt-4": {"prompt": 300, "completion": 600, "max_prompt": 8192},
+    "gpt-4-0314": {"prompt": 300, "completion": 600, "max_prompt": 8192},
+    "gpt-4-0613": {"prompt": 300, "completion": 600, "max_prompt": 8192},
+    "gpt-4-32k": {"prompt": 600, "completion": 1200, "max_prompt": 32768}, # Does not exist or don't have access to it error.
+    "gpt-4-32k-0314": {"prompt": 600, "completion": 1200, "max_prompt": 32768}, # Does not exist or don't have access to it error.
+    "gpt-4-32k-0613": {"prompt": 600, "completion": 1200}, # Does not exist or don't have access to it error.
+    "gpt-4-1106-preview": {"prompt": 100, "completion": 300, "max_prompt": 128000}, # This is not a typo. It is actually 128k.
+    "gpt-4-1106-vision-preview": {"prompt": 100, "completion": 300, "max_prompt": 4096}, # Does not exist or don't have access to it error.
+    "text-embedding-ada-002": {"prompt": 1, "completion": 0, "max_prompt": 8192}, # Not a chat model error.
 }

--- a/tokencost/constants.py
+++ b/tokencost/constants.py
@@ -1,37 +1,44 @@
-# Prices last updated Dec 6 2023 from https://openai.com/pricing
-# Max prompt limits last upated Dec 14 2023 by overloading the API and reading the error message.
+# Prices last updated Dec 6 2023 from: https://openai.com/pricing
+# Max prompt limits (aka context windows) last upated Dec 15 2023 from https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo
 
 """
-Prompt tokens are based on number of words + other chars (eg spaces and punctuation) in input.
-Completion tokens are similarly based on how long chatGPT's response is.
+Prompt (aka context) tokens are based on number of words + other chars (eg spaces and punctuation) in input.
+Completion tokens are similarly based on how long chatGPT's response is. 
+Prompt tokens + completion tokens = total tokens.
+The max total limit is typically 1 more than the prompt token limit, so there's space for at least one completion token.
 
 You can use ChatGPT's webapp (which uses their tiktoken repo) to see how many tokens your phrase is:
 https://platform.openai.com/tokenizer
 
 Note: When asking follow-up questions, everything above and including your follow-up question
 is considered a prompt (for the purpose of context) and will thus cost prompt tokens.
+
+1 Token Price Unit (TPU) is defined as 1/10,000,000 of $1 (USD). 100,000 TPUs would equate to $0.01.
 """
 
-# 1 Token Price Unit (TPU) = 1/10,000,000 of $1 (USD). 100,000 TPUs would equate to $0.01.
-# How to read the below: Each prompt token costs __ TPUs per token, and each completion token costs __ TPUs per token.
-# Max prompt token limit of each model is __. The max total limit is typically 1 more than the prompt token limit, so there's space for at least one completion token.
 
+# How to read TOKEN_COSTS:
+# Each prompt token costs __ TPUs per token.
+# Each completion token costs __ TPUs per token.
+# Max prompt limit of each model is __ tokens.
 TOKEN_COSTS = {
     # Applications using the gpt-3.5-turbo name will automatically be upgraded to the new model on December 11, 2023.
+    # Note: Documentation for some of the gpt-3.5s has a max_prompt/context window ?typo? that says 4096.
+    # Can send 4097 prompt tokens (which returns 1 completion token, so total 4098) and overloading API returns error message that states limit of 4097.
     "gpt-3.5-turbo": {"prompt": 15, "completion": 20, "max_prompt": 4097},
     "gpt-3.5-turbo-0301": {"prompt": 15, "completion": 20, "max_prompt": 4097},
     "gpt-3.5-turbo-0613": {"prompt": 15, "completion": 20, "max_prompt": 4097},
     "gpt-3.5-turbo-16k": {"prompt": 30, "completion": 40, "max_prompt": 16385},
     "gpt-3.5-turbo-16k-0613": {"prompt": 30, "completion": 40, "max_prompt": 16385},
     "gpt-3.5-turbo-1106": {"prompt": 10, "completion": 20, "max_prompt": 16385},
-    "gpt-3.5-turbo-instruct": {"prompt": 15, "completion": 20}, # Not a chat model error.
+    "gpt-3.5-turbo-instruct": {"prompt": 15, "completion": 20, "max_prompt": 4096},
     "gpt-4": {"prompt": 300, "completion": 600, "max_prompt": 8192},
     "gpt-4-0314": {"prompt": 300, "completion": 600, "max_prompt": 8192},
     "gpt-4-0613": {"prompt": 300, "completion": 600, "max_prompt": 8192},
-    "gpt-4-32k": {"prompt": 600, "completion": 1200, "max_prompt": 32768}, # Does not exist or don't have access to it error.
-    "gpt-4-32k-0314": {"prompt": 600, "completion": 1200, "max_prompt": 32768}, # Does not exist or don't have access to it error.
-    "gpt-4-32k-0613": {"prompt": 600, "completion": 1200}, # Does not exist or don't have access to it error.
-    "gpt-4-1106-preview": {"prompt": 100, "completion": 300, "max_prompt": 128000}, # This is not a typo. It is actually 128k.
-    "gpt-4-1106-vision-preview": {"prompt": 100, "completion": 300, "max_prompt": 4096}, # Does not exist or don't have access to it error.
-    "text-embedding-ada-002": {"prompt": 1, "completion": 0, "max_prompt": 8192}, # Not a chat model error.
+    "gpt-4-32k": {"prompt": 600, "completion": 1200, "max_prompt": 32768},
+    "gpt-4-32k-0314": {"prompt": 600, "completion": 1200, "max_prompt": 32768},
+    "gpt-4-32k-0613": {"prompt": 600, "completion": 1200, "max_prompt": 32768},
+    "gpt-4-1106-preview": {"prompt": 100, "completion": 300, "max_prompt": 128000},  # Not a typo, actually 128k.
+    "gpt-4-vision-preview": {"prompt": 100, "completion": 300, "max_prompt": 128000},
+    "text-embedding-ada-002": {"prompt": 1, "completion": 0, "max_prompt": 8192},
 }

--- a/tokencost/constants.py
+++ b/tokencost/constants.py
@@ -16,6 +16,8 @@ is considered a prompt (for the purpose of context) and will thus cost prompt to
 1 Token Price Unit (TPU) is defined as 1/10,000,000 of $1 (USD). 100,000 TPUs would equate to $0.01.
 """
 
+USD_PER_TPU = float(10_000_000)
+CENTS_PER_TPU = float(100_000)
 
 # How to read TOKEN_COSTS:
 # Each prompt token costs __ TPUs per token.

--- a/tokencost/costs.py
+++ b/tokencost/costs.py
@@ -2,7 +2,7 @@
 Costs dictionary and utility tool for counting tokens
 """
 import tiktoken
-from typing import List
+from typing import Union, List
 from .constants import TOKEN_COSTS
 
 
@@ -12,7 +12,7 @@ from .constants import TOKEN_COSTS
 # https://github.com/anthropics/anthropic-tokenizer-typescript/blob/main/index.ts
 
 
-def count_message_tokens(messages, model):
+def count_message_tokens(messages: List, model: str) -> int:
     """Return the total number of tokens in a list of (prompt or completion) messages."""
     if not messages:
         raise KeyError("Empty message list provided.")
@@ -77,13 +77,13 @@ def count_string_tokens(string: str, model: str) -> int:
     return len(encoding.encode(string))
 
 
-def calculate_cost(prompt: List[dict] | str, completion: List[dict] | str, model: str) -> float:
+def calculate_cost(prompt: Union[List[dict], str], completion: Union[List[dict], str], model: str) -> float:
     """
     Calculate the cost of tokens in TPUs.  1 TPU = 1/10,000,000 of $1 (USD), so 100,000 TPUs = $0.01.
 
     Args:
-        prompt_tokens (List[dict] | str): List of message objects or single string prompt.
-        completion_tokens (List[dict] | str): List of message objects or single string completion.
+        prompt (Union[List[dict], str]): List of message objects or single string prompt.
+        completion (Union[List[dict], str]): List of message objects or single string completion.
         model (str): The model name.
 
     Returns:
@@ -93,20 +93,19 @@ def calculate_cost(prompt: List[dict] | str, completion: List[dict] | str, model
     if model not in TOKEN_COSTS:
         raise KeyError(
             f"""calculate_cost() is not implemented for model {model}.
-            Double check your spelling, or submit an issue/PR: https://github.com/AgentOps-AI/tokencost/blob/main/tokencost/constants.py
+            Double-check your spelling, or submit an issue/PR: https://github.com/AgentOps-AI/tokencost/blob/main/tokencost/constants.py
             """
         )
-    if type(prompt) not in [list, str] or type(completion) not in [list, str]:
-        raise KeyError(
+    if not isinstance(prompt, (list, str)) or not isinstance(completion, (list, str)):
+        raise TypeError(
             f"""Prompt and completion each must be either a string or list of message objects.
             They are {type(prompt)} and {type(completion)}, respectively.
             """
         )
-    prompt_tokens = count_string_tokens(prompt, model) if type(prompt) is str else count_message_tokens(prompt, model)
+    prompt_tokens = count_string_tokens(prompt, model) if isinstance(prompt, str) else count_message_tokens(prompt, model)
     prompt_cost = TOKEN_COSTS[model]["prompt"]
     print(f"{prompt_cost=}")
-    completion_tokens = count_string_tokens(completion, model) if type(
-        completion) is str else count_message_tokens(completion, model)
+    completion_tokens = count_string_tokens(completion, model) if isinstance(completion, str) else count_message_tokens(completion, model)
     completion_cost = TOKEN_COSTS[model]["completion"]
     print(f"{completion_cost=}")
 


### PR DESCRIPTION
Closes #5 

Able to run locally on iPython for strings:
![image](https://github.com/AgentOps-AI/tokencost/assets/29530389/8e9b78e7-6f14-4df3-b4b0-5c38e6189a76)

And also for messages: 
![image](https://github.com/AgentOps-AI/tokencost/assets/29530389/c814021e-b888-40af-9b8b-9108240026e3)
