### PR TITLE
Support ollama models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ tokencost = ["model_prices.json"]
 
 [project]
 name = "tokencost"
-version = "0.1.9"
+version = "0.1.91"
 authors = [
   { name = "Trisha Pan", email = "trishaepan@gmail.com" },
   { name = "Alex Reibman", email = "areibman@gmail.com" },

--- a/tokencost/costs.py
+++ b/tokencost/costs.py
@@ -50,7 +50,7 @@ def count_message_tokens(messages: List[Dict[str, str]], model: str) -> int:
         "gpt-4-32k-0314",
         "gpt-4-0613",
         "gpt-4-32k-0613",
-    }:
+    } or model.startswith('ollama/'):
         tokens_per_message = 3
         tokens_per_name = 1
     elif model == "gpt-3.5-turbo-0301":


### PR DESCRIPTION
Count message tokens similar to openai models.

Open to suggestions.

- minor version bump up because I need this change to add ollama support in [agentops](https://github.com/AgentOps-AI/agentops/pull/237) 