### PR TITLE
fix: :bug: Skip updating estimates if event isn't a prompt nor message

### DIFF
--- a/tokencost/callbacks/llama_index.py
+++ b/tokencost/callbacks/llama_index.py
@@ -39,6 +39,8 @@ class TokenCostHandler(BaseCallbackHandler):
             estimates = calculate_all_costs_and_tokens(
                 messages_str, response, self.model
             )
+        else:
+            return
 
         self.prompt_cost += estimates["prompt_cost"]
         self.completion_cost += estimates["completion_cost"]


### PR DESCRIPTION
Sometimes running TokenCost with LlamaIndex was failing for me due to the `estimates` object only being defined if the event payload contains prompt or messages. This PR fixes this by skipping events that don't match these conditions.