### PR TITLE
Implement tach to define module boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Tach Check
+
+on: [pull_request]
+
+jobs:
+  tach-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tach
+
+    - name: Run Tach
+      run: tach check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "pytest>=7.4.4",
     "flake8>=3.1.0",
     "coverage[toml]>=7.4.0",
+    "tach==0.6.9",
 ]
 llama-index = [
     "llama-index>=0.10.23"

--- a/tach.yml
+++ b/tach.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/gauge-sh/tach/v0.6.9/public/tach-yml-schema.json
+modules:
+  - path: tokencost
+    depends_on:
+      - tokencost.constants
+      - tokencost.costs
+  - path: tokencost.callbacks.llama_index
+    depends_on:
+      - tokencost
+  - path: tokencost.constants
+    depends_on: []
+  - path: tokencost.costs
+    depends_on:
+      - tokencost.constants
+  - path: update_prices
+    depends_on:
+      - tokencost
+exclude:
+  - .*__pycache__
+  - .*egg-info
+  - docs
+  - tests
+  - venv
+source_root: .


### PR DESCRIPTION
This PR introduces [Tach](https://github.com/gauge-sh/tach) to maintain clean module boundaries. It is added as an optional dev dependency and as a CI check in GitHub Actions.

If changes are made which introduce new cross-module dependencies, they will cause `tach check` to fail and point out the offending imports. If they represent an intentional design change, they can be acknowledged with `tach sync`.

Particularly for new contributors, it is helpful to have an automatic check to validate that new changes do not violate the intended architecture of the project. Tach also serves as documentation of the logical flow of the project through tach.yml and [`tach show`](https://show.gauge.sh/?uid=eeb998d0-8861-41de-ae67-b272a3ecff70)
![image](https://github.com/AgentOps-AI/tokencost/assets/10570340/4ce61ac6-254a-4fde-8f8d-1d263109f7ae)

Tach docs are here: https://docs.gauge.sh/