### PR TITLE
Add support for proxy servers

### DIFF
--- a/tokencost/constants.py
+++ b/tokencost/constants.py
@@ -34,7 +34,7 @@ async def fetch_costs():
     Raises:
         Exception: If the request fails.
     """
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(trust_env=True) as session:
         async with session.get(PRICES_URL) as response:
             if response.status == 200:
                 return await response.json(content_type=None)


### PR DESCRIPTION
Add `trust_env=True` so that AIOHTTP will use the proxy server defined in the environment, if any.

If this is not done, the following import will result in a (long) timeout:

```from tokencost import calculate_prompt_cost, calculate_completion_cost```