### PR TITLE
Fix 'Failed to update TOKEN_COSTS: name 'TOKEN_COSTS' is not defined'

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,10 +287,13 @@ Units denominated in USD. All prices can be located in `model_prices.json`.
 | claude-2                                                              | $ 8.00                            | $24.00                                | 100,000             |                8191 |
 | claude-2.1                                                            | $ 8.00                            | $24.00                                | 200,000             |                8191 |
 | claude-3-haiku-20240307                                               | $0.25                             | $1.25                                 | 200,000             |                4096 |
+| claude-3-haiku-latest                                                 | $0.25                             | $1.25                                 | 200,000             |                4096 |
 | claude-3-opus-20240229                                                | $15.00                            | $75.00                                | 200,000             |                4096 |
+| claude-3-opus-latest                                                  | $15.00                            | $75.00                                | 200,000             |                4096 |
 | claude-3-sonnet-20240229                                              | $ 3.00                            | $15.00                                | 200,000             |                4096 |
 | claude-3-5-sonnet-20240620                                            | $ 3.00                            | $15.00                                | 200,000             |                8192 |
 | claude-3-5-sonnet-20241022                                            | $ 3.00                            | $15.00                                | 200,000             |                8192 |
+| claude-3-5-sonnet-latest                                              | $ 3.00                            | $15.00                                | 200,000             |                8192 |
 | text-bison                                                            | --                                | --                                    | 8,192               |                2048 |
 | text-bison@001                                                        | --                                | --                                    | 8,192               |                1024 |
 | text-bison@002                                                        | --                                | --                                    | 8,192               |                1024 |
@@ -408,12 +411,12 @@ Units denominated in USD. All prices can be located in `model_prices.json`.
 | rerank-multilingual-v3.0                                              | $ 0.00                            | $ 0.00                                | 4,096               |                4096 |
 | rerank-english-v2.0                                                   | $ 0.00                            | $ 0.00                                | 4,096               |                4096 |
 | rerank-multilingual-v2.0                                              | $ 0.00                            | $ 0.00                                | 4,096               |                4096 |
-| embed-english-v3.0                                                    | $0.1                              | $ 0.00                                | 512                 |                 nan |
-| embed-english-light-v3.0                                              | $0.1                              | $ 0.00                                | 512                 |                 nan |
-| embed-multilingual-v3.0                                               | $0.1                              | $ 0.00                                | 512                 |                 nan |
-| embed-english-v2.0                                                    | $0.1                              | $ 0.00                                | 512                 |                 nan |
-| embed-english-light-v2.0                                              | $0.1                              | $ 0.00                                | 512                 |                 nan |
-| embed-multilingual-v2.0                                               | $0.1                              | $ 0.00                                | 256                 |                 nan |
+| embed-english-v3.0                                                    | $0.1                              | $ 0.00                                | 1,024               |                 nan |
+| embed-english-light-v3.0                                              | $0.1                              | $ 0.00                                | 1,024               |                 nan |
+| embed-multilingual-v3.0                                               | $0.1                              | $ 0.00                                | 1,024               |                 nan |
+| embed-english-v2.0                                                    | $0.1                              | $ 0.00                                | 4,096               |                 nan |
+| embed-english-light-v2.0                                              | $0.1                              | $ 0.00                                | 1,024               |                 nan |
+| embed-multilingual-v2.0                                               | $0.1                              | $ 0.00                                | 768                 |                 nan |
 | replicate/meta/llama-2-13b                                            | $0.1                              | $0.5                                  | 4,096               |                4096 |
 | replicate/meta/llama-2-13b-chat                                       | $0.1                              | $0.5                                  | 4,096               |                4096 |
 | replicate/meta/llama-2-70b                                            | $0.65                             | $2.75                                 | 4,096               |                4096 |
@@ -436,6 +439,7 @@ Units denominated in USD. All prices can be located in `model_prices.json`.
 | openrouter/anthropic/claude-3-haiku                                   | $0.25                             | $1.25                                 | nan                 |                 nan |
 | openrouter/anthropic/claude-3-haiku-20240307                          | $0.25                             | $1.25                                 | 200,000             |                4096 |
 | anthropic/claude-3-5-sonnet-20241022                                  | $ 3.00                            | $15.00                                | 200,000             |                8192 |
+| anthropic/claude-3-5-sonnet-latest                                    | $ 3.00                            | $15.00                                | 200,000             |                8192 |
 | openrouter/anthropic/claude-3.5-sonnet                                | $ 3.00                            | $15.00                                | 200,000             |                8192 |
 | openrouter/anthropic/claude-3.5-sonnet:beta                           | $ 3.00                            | $15.00                                | 200,000             |                8192 |
 | openrouter/anthropic/claude-3-sonnet                                  | $ 3.00                            | $15.00                                | nan                 |                 nan |
@@ -514,6 +518,7 @@ Units denominated in USD. All prices can be located in `model_prices.json`.
 | anthropic.claude-3-sonnet-20240229-v1:0                               | $ 3.00                            | $15.00                                | 200,000             |                4096 |
 | anthropic.claude-3-5-sonnet-20240620-v1:0                             | $ 3.00                            | $15.00                                | 200,000             |                4096 |
 | anthropic.claude-3-5-sonnet-20241022-v2:0                             | $ 3.00                            | $15.00                                | 200,000             |                4096 |
+| anthropic.claude-3-5-sonnet-latest-v2:0                               | $ 3.00                            | $15.00                                | 200,000             |                4096 |
 | anthropic.claude-3-haiku-20240307-v1:0                                | $0.25                             | $1.25                                 | 200,000             |                4096 |
 | anthropic.claude-3-opus-20240229-v1:0                                 | $15.00                            | $75.00                                | 200,000             |                4096 |
 | us.anthropic.claude-3-sonnet-20240229-v1:0                            | $ 3.00                            | $15.00                                | 200,000             |                4096 |
@@ -762,6 +767,8 @@ Units denominated in USD. All prices can be located in `model_prices.json`.
 | databricks/databricks-mpt-7b-instruct                                 | $0.50001                          | $ 0.00                                | 8,192               |                8192 |
 | databricks/databricks-bge-large-en                                    | $0.10003                          | $ 0.00                                | 512                 |                 nan |
 | databricks/databricks-gte-large-en                                    | $0.12999                          | $ 0.00                                | 8,192               |                 nan |
+| azure/gpt-4o-mini-2024-07-18                                          | $0.165                            | $0.66                                 | 128,000             |               16384 |
+| amazon.titan-embed-image-v1                                           | $0.8                              | $ 0.00                                | 128                 |                 nan |
 
 ### Callback handlers
 You may also calculate token costs in LLM wrapper/framework libraries using callbacks. 

--- a/pricing_table.md
+++ b/pricing_table.md
@@ -168,10 +168,13 @@
 | claude-2                                                              | $ 8.00                            | $24.00                                | 100,000             |                8191 |
 | claude-2.1                                                            | $ 8.00                            | $24.00                                | 200,000             |                8191 |
 | claude-3-haiku-20240307                                               | $0.25                             | $1.25                                 | 200,000             |                4096 |
+| claude-3-haiku-latest                                                 | $0.25                             | $1.25                                 | 200,000             |                4096 |
 | claude-3-opus-20240229                                                | $15.00                            | $75.00                                | 200,000             |                4096 |
+| claude-3-opus-latest                                                  | $15.00                            | $75.00                                | 200,000             |                4096 |
 | claude-3-sonnet-20240229                                              | $ 3.00                            | $15.00                                | 200,000             |                4096 |
 | claude-3-5-sonnet-20240620                                            | $ 3.00                            | $15.00                                | 200,000             |                8192 |
 | claude-3-5-sonnet-20241022                                            | $ 3.00                            | $15.00                                | 200,000             |                8192 |
+| claude-3-5-sonnet-latest                                              | $ 3.00                            | $15.00                                | 200,000             |                8192 |
 | text-bison                                                            | --                                | --                                    | 8,192               |                2048 |
 | text-bison@001                                                        | --                                | --                                    | 8,192               |                1024 |
 | text-bison@002                                                        | --                                | --                                    | 8,192               |                1024 |
@@ -289,12 +292,12 @@
 | rerank-multilingual-v3.0                                              | $ 0.00                            | $ 0.00                                | 4,096               |                4096 |
 | rerank-english-v2.0                                                   | $ 0.00                            | $ 0.00                                | 4,096               |                4096 |
 | rerank-multilingual-v2.0                                              | $ 0.00                            | $ 0.00                                | 4,096               |                4096 |
-| embed-english-v3.0                                                    | $0.1                              | $ 0.00                                | 512                 |                 nan |
-| embed-english-light-v3.0                                              | $0.1                              | $ 0.00                                | 512                 |                 nan |
-| embed-multilingual-v3.0                                               | $0.1                              | $ 0.00                                | 512                 |                 nan |
-| embed-english-v2.0                                                    | $0.1                              | $ 0.00                                | 512                 |                 nan |
-| embed-english-light-v2.0                                              | $0.1                              | $ 0.00                                | 512                 |                 nan |
-| embed-multilingual-v2.0                                               | $0.1                              | $ 0.00                                | 256                 |                 nan |
+| embed-english-v3.0                                                    | $0.1                              | $ 0.00                                | 1,024               |                 nan |
+| embed-english-light-v3.0                                              | $0.1                              | $ 0.00                                | 1,024               |                 nan |
+| embed-multilingual-v3.0                                               | $0.1                              | $ 0.00                                | 1,024               |                 nan |
+| embed-english-v2.0                                                    | $0.1                              | $ 0.00                                | 4,096               |                 nan |
+| embed-english-light-v2.0                                              | $0.1                              | $ 0.00                                | 1,024               |                 nan |
+| embed-multilingual-v2.0                                               | $0.1                              | $ 0.00                                | 768                 |                 nan |
 | replicate/meta/llama-2-13b                                            | $0.1                              | $0.5                                  | 4,096               |                4096 |
 | replicate/meta/llama-2-13b-chat                                       | $0.1                              | $0.5                                  | 4,096               |                4096 |
 | replicate/meta/llama-2-70b                                            | $0.65                             | $2.75                                 | 4,096               |                4096 |
@@ -317,6 +320,7 @@
 | openrouter/anthropic/claude-3-haiku                                   | $0.25                             | $1.25                                 | nan                 |                 nan |
 | openrouter/anthropic/claude-3-haiku-20240307                          | $0.25                             | $1.25                                 | 200,000             |                4096 |
 | anthropic/claude-3-5-sonnet-20241022                                  | $ 3.00                            | $15.00                                | 200,000             |                8192 |
+| anthropic/claude-3-5-sonnet-latest                                    | $ 3.00                            | $15.00                                | 200,000             |                8192 |
 | openrouter/anthropic/claude-3.5-sonnet                                | $ 3.00                            | $15.00                                | 200,000             |                8192 |
 | openrouter/anthropic/claude-3.5-sonnet:beta                           | $ 3.00                            | $15.00                                | 200,000             |                8192 |
 | openrouter/anthropic/claude-3-sonnet                                  | $ 3.00                            | $15.00                                | nan                 |                 nan |
@@ -395,6 +399,7 @@
 | anthropic.claude-3-sonnet-20240229-v1:0                               | $ 3.00                            | $15.00                                | 200,000             |                4096 |
 | anthropic.claude-3-5-sonnet-20240620-v1:0                             | $ 3.00                            | $15.00                                | 200,000             |                4096 |
 | anthropic.claude-3-5-sonnet-20241022-v2:0                             | $ 3.00                            | $15.00                                | 200,000             |                4096 |
+| anthropic.claude-3-5-sonnet-latest-v2:0                               | $ 3.00                            | $15.00                                | 200,000             |                4096 |
 | anthropic.claude-3-haiku-20240307-v1:0                                | $0.25                             | $1.25                                 | 200,000             |                4096 |
 | anthropic.claude-3-opus-20240229-v1:0                                 | $15.00                            | $75.00                                | 200,000             |                4096 |
 | us.anthropic.claude-3-sonnet-20240229-v1:0                            | $ 3.00                            | $15.00                                | 200,000             |                4096 |
@@ -643,3 +648,5 @@
 | databricks/databricks-mpt-7b-instruct                                 | $0.50001                          | $ 0.00                                | 8,192               |                8192 |
 | databricks/databricks-bge-large-en                                    | $0.10003                          | $ 0.00                                | 512                 |                 nan |
 | databricks/databricks-gte-large-en                                    | $0.12999                          | $ 0.00                                | 8,192               |                 nan |
+| azure/gpt-4o-mini-2024-07-18                                          | $0.165                            | $0.66                                 | 128,000             |               16384 |
+| amazon.titan-embed-image-v1                                           | $0.8                              | $ 0.00                                | 128                 |                 nan |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ tokencost = ["model_prices.json"]
 
 [project]
 name = "tokencost"
-version = "0.1.15"
+version = "0.1.16"
 authors = [
   { name = "Trisha Pan", email = "trishaepan@gmail.com" },
   { name = "Alex Reibman", email = "areibman@gmail.com" },

--- a/tokencost/constants.py
+++ b/tokencost/constants.py
@@ -46,8 +46,7 @@ async def update_token_costs():
     """Update the TOKEN_COSTS dictionary with the latest costs from the LiteLLM cost tracker asynchronously."""
     global TOKEN_COSTS
     try:
-        fetched_costs = await fetch_costs()
-        TOKEN_COSTS.update(fetched_costs)
+        TOKEN_COSTS = await fetch_costs()
         # Safely remove 'sample_spec' if it exists
         TOKEN_COSTS.pop('sample_spec', None)
     except Exception as e:

--- a/tokencost/constants.py
+++ b/tokencost/constants.py
@@ -46,8 +46,9 @@ async def update_token_costs():
     """Update the TOKEN_COSTS dictionary with the latest costs from the LiteLLM cost tracker asynchronously."""
     global TOKEN_COSTS
     try:
-        TOKEN_COSTS = await fetch_costs()
+        fetched_costs = await fetch_costs()
         # Safely remove 'sample_spec' if it exists
+        TOKEN_COSTS.update(fetched_costs)
         TOKEN_COSTS.pop('sample_spec', None)
     except Exception as e:
         logger.error(f"Failed to update TOKEN_COSTS: {e}")
@@ -59,7 +60,7 @@ with open(os.path.join(os.path.dirname(__file__), "model_prices.json"), "r") as 
 
 # Ensure TOKEN_COSTS is up to date when the module is loaded
 try:
+    TOKEN_COSTS = TOKEN_COSTS_STATIC
     asyncio.run(update_token_costs())
 except Exception:
     logger.error('Failed to update token costs. Using static costs.')
-    TOKEN_COSTS = TOKEN_COSTS_STATIC

--- a/tokencost/model_prices.json
+++ b/tokencost/model_prices.json
@@ -3397,48 +3397,50 @@
         "mode": "rerank"
     },
     "embed-english-v3.0": {
-        "max_tokens": 512,
-        "max_input_tokens": 512,
+        "max_tokens": 1024,
+        "max_input_tokens": 1024,
         "input_cost_per_token": 1e-07,
+        "input_cost_per_image": 0.0001,
         "output_cost_per_token": 0.0,
         "litellm_provider": "cohere",
-        "mode": "embedding"
+        "mode": "embedding",
+        "supports_image_input": true
     },
     "embed-english-light-v3.0": {
-        "max_tokens": 512,
-        "max_input_tokens": 512,
+        "max_tokens": 1024,
+        "max_input_tokens": 1024,
         "input_cost_per_token": 1e-07,
         "output_cost_per_token": 0.0,
         "litellm_provider": "cohere",
         "mode": "embedding"
     },
     "embed-multilingual-v3.0": {
-        "max_tokens": 512,
-        "max_input_tokens": 512,
+        "max_tokens": 1024,
+        "max_input_tokens": 1024,
         "input_cost_per_token": 1e-07,
         "output_cost_per_token": 0.0,
         "litellm_provider": "cohere",
         "mode": "embedding"
     },
     "embed-english-v2.0": {
-        "max_tokens": 512,
-        "max_input_tokens": 512,
+        "max_tokens": 4096,
+        "max_input_tokens": 4096,
         "input_cost_per_token": 1e-07,
         "output_cost_per_token": 0.0,
         "litellm_provider": "cohere",
         "mode": "embedding"
     },
     "embed-english-light-v2.0": {
-        "max_tokens": 512,
-        "max_input_tokens": 512,
+        "max_tokens": 1024,
+        "max_input_tokens": 1024,
         "input_cost_per_token": 1e-07,
         "output_cost_per_token": 0.0,
         "litellm_provider": "cohere",
         "mode": "embedding"
     },
     "embed-multilingual-v2.0": {
-        "max_tokens": 256,
-        "max_input_tokens": 256,
+        "max_tokens": 768,
+        "max_input_tokens": 768,
         "input_cost_per_token": 1e-07,
         "output_cost_per_token": 0.0,
         "litellm_provider": "cohere",
@@ -4347,7 +4349,8 @@
         "litellm_provider": "bedrock",
         "mode": "chat",
         "supports_function_calling": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_assistant_prefill": true
     },
     "anthropic.claude-3-5-sonnet-latest-v2:0": {
         "max_tokens": 4096,
@@ -4413,7 +4416,8 @@
         "litellm_provider": "bedrock",
         "mode": "chat",
         "supports_function_calling": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_assistant_prefill": true
     },
     "us.anthropic.claude-3-haiku-20240307-v1:0": {
         "max_tokens": 4096,
@@ -4468,7 +4472,8 @@
         "litellm_provider": "bedrock",
         "mode": "chat",
         "supports_function_calling": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_assistant_prefill": true
     },
     "eu.anthropic.claude-3-haiku-20240307-v1:0": {
         "max_tokens": 4096,
@@ -6662,5 +6667,31 @@
         "metadata": {
             "notes": "Input/output cost per token is dbu cost * $0.070, based on databricks Llama 3.1 70B conversion. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         }
+    },
+    "azure/gpt-4o-mini-2024-07-18": {
+        "max_tokens": 16384,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "input_cost_per_token": 1.65e-07,
+        "output_cost_per_token": 6.6e-07,
+        "cache_read_input_token_cost": 7.5e-08,
+        "litellm_provider": "azure",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true,
+        "supports_prompt_caching": true
+    },
+    "amazon.titan-embed-image-v1": {
+        "max_tokens": 128,
+        "max_input_tokens": 128,
+        "output_vector_size": 1024,
+        "input_cost_per_token": 8e-07,
+        "input_cost_per_image": 6e-05,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "bedrock",
+        "supports_image_input": true,
+        "mode": "embedding",
+        "source": "https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/providers?model=amazon.titan-image-generator-v1"
     }
 }

--- a/update_prices.py
+++ b/update_prices.py
@@ -33,8 +33,8 @@ if diff_dicts(model_prices, tokencost.TOKEN_COSTS):
         json.dump(tokencost.TOKEN_COSTS, f, indent=4)
 # Load the data
 df = pd.DataFrame(tokencost.TOKEN_COSTS).T
-df['max_input_tokens'].iloc[1:] = df['max_input_tokens'].iloc[1:].apply(lambda x: '{:,.0f}'.format(x))
-df['max_tokens'].iloc[1:] = df['max_tokens'].iloc[1:].apply(lambda x: '{:,.0f}'.format(x))
+df.loc[df.index[1:], 'max_input_tokens'] = df['max_input_tokens'].iloc[1:].apply(lambda x: '{:,.0f}'.format(x))
+df.loc[df.index[1:], 'max_tokens'] = df['max_tokens'].iloc[1:].apply(lambda x: '{:,.0f}'.format(x))
 
 
 # Updated function to format the cost or handle NaN
@@ -45,7 +45,7 @@ def format_cost(x):
         return '--'
     else:
         price_per_million = Decimal(str(x)) * Decimal(str(1_000_000))
-        print(price_per_million)
+        # print(price_per_million)
         normalized = price_per_million.normalize()
         formatted_price = '{:2f}'.format(normalized)
 


### PR DESCRIPTION
Revert [this commit](https://github.com/AgentOps-AI/tokencost/commit/cd7ee73d690e06910661bbdb27d7a2a0c8fe0f12)

This causes an error as the token cost is never initialized as a dict (or as any thing), and an `update` is tried on it, which results in an exception like the one I mention in the first line of the commit. Then the error handling logic makes it such that the static token costs are loaded (so no actual exception is thrown in the end, but the static costs are always used)