### PR TITLE
Update prices as on `08-11-2024`

### DIFF
--- a/pricing_table.md
+++ b/pricing_table.md
@@ -208,17 +208,17 @@
 | gemini-1.0-ultra                                                      | $0.5                              | $1.5                                  | 8,192               |                2048 |
 | gemini-1.0-ultra-001                                                  | $0.5                              | $1.5                                  | 8,192               |                2048 |
 | gemini-1.0-pro-002                                                    | $0.5                              | $1.5                                  | 32,760              |                8192 |
-| gemini-1.5-pro                                                        | $0.078125                         | $0.3125                               | 2,097,152           |                8192 |
-| gemini-1.5-pro-002                                                    | $0.078125                         | $0.3125                               | 2,097,152           |                8192 |
-| gemini-1.5-pro-001                                                    | $0.078125                         | $0.3125                               | 1,000,000           |                8192 |
+| gemini-1.5-pro                                                        | $1.25                             | $ 5.00                                | 2,097,152           |                8192 |
+| gemini-1.5-pro-002                                                    | $1.25                             | $ 5.00                                | 2,097,152           |                8192 |
+| gemini-1.5-pro-001                                                    | $1.25                             | $ 5.00                                | 1,000,000           |                8192 |
 | gemini-1.5-pro-preview-0514                                           | $0.078125                         | $0.3125                               | 1,000,000           |                8192 |
 | gemini-1.5-pro-preview-0215                                           | $0.078125                         | $0.3125                               | 1,000,000           |                8192 |
 | gemini-1.5-pro-preview-0409                                           | $0.078125                         | $0.3125                               | 1,000,000           |                8192 |
-| gemini-1.5-flash                                                      | $0.004688                         | $0.0046875                            | 1,000,000           |                8192 |
+| gemini-1.5-flash                                                      | $0.075                            | $0.3                                  | 1,000,000           |                8192 |
 | gemini-1.5-flash-exp-0827                                             | $0.004688                         | $0.0046875                            | 1,000,000           |                8192 |
-| gemini-1.5-flash-002                                                  | $0.004688                         | $0.0046875                            | 1,048,576           |                8192 |
-| gemini-1.5-flash-001                                                  | $0.004688                         | $0.0046875                            | 1,000,000           |                8192 |
-| gemini-1.5-flash-preview-0514                                         | $0.004688                         | $0.0046875                            | 1,000,000           |                8192 |
+| gemini-1.5-flash-002                                                  | $0.075                            | $0.3                                  | 1,048,576           |                8192 |
+| gemini-1.5-flash-001                                                  | $0.075                            | $0.3                                  | 1,000,000           |                8192 |
+| gemini-1.5-flash-preview-0514                                         | $0.075                            | $0.0046875                            | 1,000,000           |                8192 |
 | gemini-pro-experimental                                               | $ 0.00                            | $ 0.00                                | 1,000,000           |                8192 |
 | gemini-flash-experimental                                             | $ 0.00                            | $ 0.00                                | 1,000,000           |                8192 |
 | gemini-pro-vision                                                     | $0.25                             | $0.5                                  | 16,384              |                2048 |
@@ -234,7 +234,7 @@
 | vertex_ai/meta/llama3-405b-instruct-maas                              | $ 0.00                            | $ 0.00                                | 32,000              |               32000 |
 | vertex_ai/meta/llama3-70b-instruct-maas                               | $ 0.00                            | $ 0.00                                | 32,000              |               32000 |
 | vertex_ai/meta/llama3-8b-instruct-maas                                | $ 0.00                            | $ 0.00                                | 32,000              |               32000 |
-| vertex_ai/meta/llama-3.2-90b-vision-instruct-maas                     | $ 0.00                            | $ 0.00                                | 128,000             |                8192 |
+| vertex_ai/meta/llama-3.2-90b-vision-instruct-maas                     | $ 0.00                            | $ 0.00                                | 128,000             |                2048 |
 | vertex_ai/mistral-large@latest                                        | $ 3.00                            | $ 9.00                                | 128,000             |                8191 |
 | vertex_ai/mistral-large@2407                                          | $ 3.00                            | $ 9.00                                | 128,000             |                8191 |
 | vertex_ai/mistral-nemo@latest                                         | $ 3.00                            | $ 3.00                                | 128,000             |              128000 |
@@ -650,3 +650,24 @@
 | databricks/databricks-gte-large-en                                    | $0.12999                          | $ 0.00                                | 8,192               |                 nan |
 | azure/gpt-4o-mini-2024-07-18                                          | $0.165                            | $0.66                                 | 128,000             |               16384 |
 | amazon.titan-embed-image-v1                                           | $0.8                              | $ 0.00                                | 128                 |                 nan |
+| azure_ai/mistral-large-2407                                           | $ 2.00                            | $ 6.00                                | 128,000             |                4096 |
+| azure_ai/ministral-3b                                                 | $0.04                             | $0.04                                 | 128,000             |                4096 |
+| azure_ai/Llama-3.2-11B-Vision-Instruct                                | $0.37                             | $0.37                                 | 128,000             |                2048 |
+| azure_ai/Llama-3.2-90B-Vision-Instruct                                | $2.04                             | $2.04                                 | 128,000             |                2048 |
+| azure_ai/Phi-3.5-mini-instruct                                        | $0.13                             | $0.52                                 | 128,000             |                4096 |
+| azure_ai/Phi-3.5-vision-instruct                                      | $0.13                             | $0.52                                 | 128,000             |                4096 |
+| azure_ai/Phi-3.5-MoE-instruct                                         | $0.16                             | $0.64                                 | 128,000             |                4096 |
+| azure_ai/Phi-3-mini-4k-instruct                                       | $0.13                             | $0.52                                 | 4,096               |                4096 |
+| azure_ai/Phi-3-mini-128k-instruct                                     | $0.13                             | $0.52                                 | 128,000             |                4096 |
+| azure_ai/Phi-3-small-8k-instruct                                      | $0.15                             | $0.6                                  | 8,192               |                4096 |
+| azure_ai/Phi-3-small-128k-instruct                                    | $0.15                             | $0.6                                  | 128,000             |                4096 |
+| azure_ai/Phi-3-medium-4k-instruct                                     | $0.17                             | $0.68                                 | 4,096               |                4096 |
+| azure_ai/Phi-3-medium-128k-instruct                                   | $0.17                             | $0.68                                 | 128,000             |                4096 |
+| xai/grok-beta                                                         | $ 5.00                            | $15.00                                | 131,072             |              131072 |
+| claude-3-5-haiku-20241022                                             | $ 1.00                            | $ 5.00                                | 200,000             |                4096 |
+| vertex_ai/claude-3-5-haiku@20241022                                   | $ 1.00                            | $ 5.00                                | 200,000             |                4096 |
+| openrouter/anthropic/claude-3-5-haiku                                 | $ 1.00                            | $ 5.00                                | nan                 |                 nan |
+| openrouter/anthropic/claude-3-5-haiku-20241022                        | $ 1.00                            | $ 5.00                                | 200,000             |                4096 |
+| anthropic.claude-3-5-haiku-20241022-v1:0                              | $ 1.00                            | $ 5.00                                | 200,000             |                4096 |
+| us.anthropic.claude-3-5-haiku-20241022-v1:0                           | $ 1.00                            | $ 5.00                                | 200,000             |                4096 |
+| eu.anthropic.claude-3-5-haiku-20241022-v1:0                           | $ 1.00                            | $ 5.00                                | 200,000             |                4096 |

--- a/tokencost/model_prices.json
+++ b/tokencost/model_prices.json
@@ -65,6 +65,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
         "supports_vision": true,
         "supports_prompt_caching": true
     },
@@ -79,6 +80,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
         "supports_vision": true,
         "supports_prompt_caching": true
     },
@@ -93,7 +95,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_prompt_caching": true
     },
     "o1-mini-2024-09-12": {
@@ -107,7 +109,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_prompt_caching": true
     },
     "o1-preview": {
@@ -121,7 +123,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_prompt_caching": true
     },
     "o1-preview-2024-09-12": {
@@ -135,7 +137,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_prompt_caching": true
     },
     "chatgpt-4o-latest": {
@@ -175,6 +177,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
         "supports_vision": true,
         "supports_prompt_caching": true
     },
@@ -446,6 +449,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
         "supports_vision": true
     },
     "ft:gpt-4o-mini-2024-07-18": {
@@ -458,6 +462,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
         "supports_vision": true
     },
     "ft:davinci-002": {
@@ -637,7 +642,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_prompt_caching": true
     },
     "azure/o1-mini-2024-09-12": {
@@ -651,7 +656,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_prompt_caching": true
     },
     "azure/o1-preview": {
@@ -665,7 +670,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_prompt_caching": true
     },
     "azure/o1-preview-2024-09-12": {
@@ -679,7 +684,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_prompt_caching": true
     },
     "azure/gpt-4o": {
@@ -706,6 +711,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
         "supports_vision": true
     },
     "azure/gpt-4o-2024-05-13": {
@@ -731,6 +737,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
         "supports_vision": true
     },
     "azure/global-standard/gpt-4o-mini": {
@@ -743,6 +750,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
         "supports_vision": true
     },
     "azure/gpt-4o-mini": {
@@ -756,6 +764,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
         "supports_vision": true,
         "supports_prompt_caching": true
     },
@@ -2202,16 +2211,16 @@
         "input_cost_per_image": 0.00032875,
         "input_cost_per_audio_per_second": 3.125e-05,
         "input_cost_per_video_per_second": 0.00032875,
-        "input_cost_per_token": 7.8125e-08,
+        "input_cost_per_token": 1.25e-06,
         "input_cost_per_character": 3.125e-07,
         "input_cost_per_image_above_128k_tokens": 0.0006575,
         "input_cost_per_video_per_second_above_128k_tokens": 0.0006575,
         "input_cost_per_audio_per_second_above_128k_tokens": 6.25e-05,
-        "input_cost_per_token_above_128k_tokens": 1.5625e-07,
+        "input_cost_per_token_above_128k_tokens": 2.5e-06,
         "input_cost_per_character_above_128k_tokens": 6.25e-07,
-        "output_cost_per_token": 3.125e-07,
+        "output_cost_per_token": 5e-06,
         "output_cost_per_character": 1.25e-06,
-        "output_cost_per_token_above_128k_tokens": 6.25e-07,
+        "output_cost_per_token_above_128k_tokens": 1e-05,
         "output_cost_per_character_above_128k_tokens": 2.5e-06,
         "litellm_provider": "vertex_ai-language-models",
         "mode": "chat",
@@ -2228,16 +2237,16 @@
         "input_cost_per_image": 0.00032875,
         "input_cost_per_audio_per_second": 3.125e-05,
         "input_cost_per_video_per_second": 0.00032875,
-        "input_cost_per_token": 7.8125e-08,
+        "input_cost_per_token": 1.25e-06,
         "input_cost_per_character": 3.125e-07,
         "input_cost_per_image_above_128k_tokens": 0.0006575,
         "input_cost_per_video_per_second_above_128k_tokens": 0.0006575,
         "input_cost_per_audio_per_second_above_128k_tokens": 6.25e-05,
-        "input_cost_per_token_above_128k_tokens": 1.5625e-07,
+        "input_cost_per_token_above_128k_tokens": 2.5e-06,
         "input_cost_per_character_above_128k_tokens": 6.25e-07,
-        "output_cost_per_token": 3.125e-07,
+        "output_cost_per_token": 5e-06,
         "output_cost_per_character": 1.25e-06,
-        "output_cost_per_token_above_128k_tokens": 6.25e-07,
+        "output_cost_per_token_above_128k_tokens": 1e-05,
         "output_cost_per_character_above_128k_tokens": 2.5e-06,
         "litellm_provider": "vertex_ai-language-models",
         "mode": "chat",
@@ -2254,16 +2263,16 @@
         "input_cost_per_image": 0.00032875,
         "input_cost_per_audio_per_second": 3.125e-05,
         "input_cost_per_video_per_second": 0.00032875,
-        "input_cost_per_token": 7.8125e-08,
+        "input_cost_per_token": 1.25e-06,
         "input_cost_per_character": 3.125e-07,
         "input_cost_per_image_above_128k_tokens": 0.0006575,
         "input_cost_per_video_per_second_above_128k_tokens": 0.0006575,
         "input_cost_per_audio_per_second_above_128k_tokens": 6.25e-05,
-        "input_cost_per_token_above_128k_tokens": 1.5625e-07,
+        "input_cost_per_token_above_128k_tokens": 2.5e-06,
         "input_cost_per_character_above_128k_tokens": 6.25e-07,
-        "output_cost_per_token": 3.125e-07,
+        "output_cost_per_token": 5e-06,
         "output_cost_per_character": 1.25e-06,
-        "output_cost_per_token_above_128k_tokens": 6.25e-07,
+        "output_cost_per_token_above_128k_tokens": 1e-05,
         "output_cost_per_character_above_128k_tokens": 2.5e-06,
         "litellm_provider": "vertex_ai-language-models",
         "mode": "chat",
@@ -2363,17 +2372,17 @@
         "input_cost_per_image": 2e-05,
         "input_cost_per_video_per_second": 2e-05,
         "input_cost_per_audio_per_second": 2e-06,
-        "input_cost_per_token": 4.688e-09,
+        "input_cost_per_token": 7.5e-08,
         "input_cost_per_character": 1.875e-08,
         "input_cost_per_token_above_128k_tokens": 1e-06,
         "input_cost_per_character_above_128k_tokens": 2.5e-07,
         "input_cost_per_image_above_128k_tokens": 4e-05,
         "input_cost_per_video_per_second_above_128k_tokens": 4e-05,
         "input_cost_per_audio_per_second_above_128k_tokens": 4e-06,
-        "output_cost_per_token": 4.6875e-09,
-        "output_cost_per_character": 1.875e-08,
-        "output_cost_per_token_above_128k_tokens": 9.375e-09,
-        "output_cost_per_character_above_128k_tokens": 3.75e-08,
+        "output_cost_per_token": 3e-07,
+        "output_cost_per_character": 7.5e-08,
+        "output_cost_per_token_above_128k_tokens": 6e-07,
+        "output_cost_per_character_above_128k_tokens": 1.5e-07,
         "litellm_provider": "vertex_ai-language-models",
         "mode": "chat",
         "supports_system_messages": true,
@@ -2427,17 +2436,17 @@
         "input_cost_per_image": 2e-05,
         "input_cost_per_video_per_second": 2e-05,
         "input_cost_per_audio_per_second": 2e-06,
-        "input_cost_per_token": 4.688e-09,
+        "input_cost_per_token": 7.5e-08,
         "input_cost_per_character": 1.875e-08,
         "input_cost_per_token_above_128k_tokens": 1e-06,
         "input_cost_per_character_above_128k_tokens": 2.5e-07,
         "input_cost_per_image_above_128k_tokens": 4e-05,
         "input_cost_per_video_per_second_above_128k_tokens": 4e-05,
         "input_cost_per_audio_per_second_above_128k_tokens": 4e-06,
-        "output_cost_per_token": 4.6875e-09,
-        "output_cost_per_character": 1.875e-08,
-        "output_cost_per_token_above_128k_tokens": 9.375e-09,
-        "output_cost_per_character_above_128k_tokens": 3.75e-08,
+        "output_cost_per_token": 3e-07,
+        "output_cost_per_character": 7.5e-08,
+        "output_cost_per_token_above_128k_tokens": 6e-07,
+        "output_cost_per_character_above_128k_tokens": 1.5e-07,
         "litellm_provider": "vertex_ai-language-models",
         "mode": "chat",
         "supports_system_messages": true,
@@ -2459,17 +2468,17 @@
         "input_cost_per_image": 2e-05,
         "input_cost_per_video_per_second": 2e-05,
         "input_cost_per_audio_per_second": 2e-06,
-        "input_cost_per_token": 4.688e-09,
+        "input_cost_per_token": 7.5e-08,
         "input_cost_per_character": 1.875e-08,
         "input_cost_per_token_above_128k_tokens": 1e-06,
         "input_cost_per_character_above_128k_tokens": 2.5e-07,
         "input_cost_per_image_above_128k_tokens": 4e-05,
         "input_cost_per_video_per_second_above_128k_tokens": 4e-05,
         "input_cost_per_audio_per_second_above_128k_tokens": 4e-06,
-        "output_cost_per_token": 4.6875e-09,
-        "output_cost_per_character": 1.875e-08,
-        "output_cost_per_token_above_128k_tokens": 9.375e-09,
-        "output_cost_per_character_above_128k_tokens": 3.75e-08,
+        "output_cost_per_token": 3e-07,
+        "output_cost_per_character": 7.5e-08,
+        "output_cost_per_token_above_128k_tokens": 6e-07,
+        "output_cost_per_character_above_128k_tokens": 1.5e-07,
         "litellm_provider": "vertex_ai-language-models",
         "mode": "chat",
         "supports_system_messages": true,
@@ -2491,7 +2500,7 @@
         "input_cost_per_image": 2e-05,
         "input_cost_per_video_per_second": 2e-05,
         "input_cost_per_audio_per_second": 2e-06,
-        "input_cost_per_token": 4.688e-09,
+        "input_cost_per_token": 7.5e-08,
         "input_cost_per_character": 1.875e-08,
         "input_cost_per_token_above_128k_tokens": 1e-06,
         "input_cost_per_character_above_128k_tokens": 2.5e-07,
@@ -2693,14 +2702,15 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#partner-models"
     },
     "vertex_ai/meta/llama-3.2-90b-vision-instruct-maas": {
-        "max_tokens": 8192,
+        "max_tokens": 128000,
         "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
+        "max_output_tokens": 2048,
         "input_cost_per_token": 0.0,
         "output_cost_per_token": 0.0,
         "litellm_provider": "vertex_ai-llama_models",
         "mode": "chat",
         "supports_system_messages": true,
+        "supports_vision": true,
         "source": "https://console.cloud.google.com/vertex-ai/publishers/meta/model-garden/llama-3.2-90b-vision-instruct-maas"
     },
     "vertex_ai/mistral-large@latest": {
@@ -3770,7 +3780,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_vision": false
     },
     "openrouter/openai/o1-mini-2024-09-12": {
         "max_tokens": 65536,
@@ -3782,7 +3792,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_vision": false
     },
     "openrouter/openai/o1-preview": {
         "max_tokens": 32768,
@@ -3794,7 +3804,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_vision": false
     },
     "openrouter/openai/o1-preview-2024-09-12": {
         "max_tokens": 32768,
@@ -3806,7 +3816,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_vision": false
     },
     "openrouter/openai/gpt-4o": {
         "max_tokens": 4096,
@@ -6679,6 +6689,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
         "supports_vision": true,
         "supports_prompt_caching": true
     },
@@ -6693,5 +6704,234 @@
         "supports_image_input": true,
         "mode": "embedding",
         "source": "https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/providers?model=amazon.titan-image-generator-v1"
+    },
+    "azure_ai/mistral-large-2407": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 2e-06,
+        "output_cost_per_token": 6e-06,
+        "litellm_provider": "azure_ai",
+        "supports_function_calling": true,
+        "mode": "chat",
+        "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/000-000.mistral-ai-large-2407-offer?tab=Overview"
+    },
+    "azure_ai/ministral-3b": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 4e-08,
+        "output_cost_per_token": 4e-08,
+        "litellm_provider": "azure_ai",
+        "supports_function_calling": true,
+        "mode": "chat",
+        "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/000-000.ministral-3b-2410-offer?tab=Overview"
+    },
+    "azure_ai/Llama-3.2-11B-Vision-Instruct": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 2048,
+        "input_cost_per_token": 3.7e-07,
+        "output_cost_per_token": 3.7e-07,
+        "litellm_provider": "azure_ai",
+        "supports_function_calling": true,
+        "supports_vision": true,
+        "mode": "chat",
+        "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/metagenai.meta-llama-3-2-11b-vision-instruct-offer?tab=Overview"
+    },
+    "azure_ai/Llama-3.2-90B-Vision-Instruct": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 2048,
+        "input_cost_per_token": 2.04e-06,
+        "output_cost_per_token": 2.04e-06,
+        "litellm_provider": "azure_ai",
+        "supports_function_calling": true,
+        "supports_vision": true,
+        "mode": "chat",
+        "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/metagenai.meta-llama-3-2-90b-vision-instruct-offer?tab=Overview"
+    },
+    "azure_ai/Phi-3.5-mini-instruct": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 1.3e-07,
+        "output_cost_per_token": 5.2e-07,
+        "litellm_provider": "azure_ai",
+        "mode": "chat",
+        "supports_vision": false,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/"
+    },
+    "azure_ai/Phi-3.5-vision-instruct": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 1.3e-07,
+        "output_cost_per_token": 5.2e-07,
+        "litellm_provider": "azure_ai",
+        "mode": "chat",
+        "supports_vision": true,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/"
+    },
+    "azure_ai/Phi-3.5-MoE-instruct": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 1.6e-07,
+        "output_cost_per_token": 6.4e-07,
+        "litellm_provider": "azure_ai",
+        "mode": "chat",
+        "supports_vision": false,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/"
+    },
+    "azure_ai/Phi-3-mini-4k-instruct": {
+        "max_tokens": 4096,
+        "max_input_tokens": 4096,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 1.3e-07,
+        "output_cost_per_token": 5.2e-07,
+        "litellm_provider": "azure_ai",
+        "mode": "chat",
+        "supports_vision": false,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/"
+    },
+    "azure_ai/Phi-3-mini-128k-instruct": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 1.3e-07,
+        "output_cost_per_token": 5.2e-07,
+        "litellm_provider": "azure_ai",
+        "mode": "chat",
+        "supports_vision": false,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/"
+    },
+    "azure_ai/Phi-3-small-8k-instruct": {
+        "max_tokens": 8192,
+        "max_input_tokens": 8192,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 1.5e-07,
+        "output_cost_per_token": 6e-07,
+        "litellm_provider": "azure_ai",
+        "mode": "chat",
+        "supports_vision": false,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/"
+    },
+    "azure_ai/Phi-3-small-128k-instruct": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 1.5e-07,
+        "output_cost_per_token": 6e-07,
+        "litellm_provider": "azure_ai",
+        "mode": "chat",
+        "supports_vision": false,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/"
+    },
+    "azure_ai/Phi-3-medium-4k-instruct": {
+        "max_tokens": 4096,
+        "max_input_tokens": 4096,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 1.7e-07,
+        "output_cost_per_token": 6.8e-07,
+        "litellm_provider": "azure_ai",
+        "mode": "chat",
+        "supports_vision": false,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/"
+    },
+    "azure_ai/Phi-3-medium-128k-instruct": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 1.7e-07,
+        "output_cost_per_token": 6.8e-07,
+        "litellm_provider": "azure_ai",
+        "mode": "chat",
+        "supports_vision": false,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/"
+    },
+    "xai/grok-beta": {
+        "max_tokens": 131072,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "input_cost_per_token": 5e-06,
+        "output_cost_per_token": 1.5e-05,
+        "litellm_provider": "xai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_vision": true
+    },
+    "claude-3-5-haiku-20241022": {
+        "max_tokens": 4096,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 5e-06,
+        "litellm_provider": "anthropic",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "tool_use_system_prompt_tokens": 264,
+        "supports_assistant_prefill": true,
+        "supports_prompt_caching": true
+    },
+    "vertex_ai/claude-3-5-haiku@20241022": {
+        "max_tokens": 4096,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 5e-06,
+        "litellm_provider": "vertex_ai-anthropic_models",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_assistant_prefill": true
+    },
+    "openrouter/anthropic/claude-3-5-haiku": {
+        "max_tokens": 200000,
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 5e-06,
+        "litellm_provider": "openrouter",
+        "mode": "chat",
+        "supports_function_calling": true
+    },
+    "openrouter/anthropic/claude-3-5-haiku-20241022": {
+        "max_tokens": 4096,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 5e-06,
+        "litellm_provider": "openrouter",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "tool_use_system_prompt_tokens": 264
+    },
+    "anthropic.claude-3-5-haiku-20241022-v1:0": {
+        "max_tokens": 4096,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 5e-06,
+        "litellm_provider": "bedrock",
+        "mode": "chat",
+        "supports_function_calling": true
+    },
+    "us.anthropic.claude-3-5-haiku-20241022-v1:0": {
+        "max_tokens": 4096,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 5e-06,
+        "litellm_provider": "bedrock",
+        "mode": "chat",
+        "supports_function_calling": true
+    },
+    "eu.anthropic.claude-3-5-haiku-20241022-v1:0": {
+        "max_tokens": 4096,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 5e-06,
+        "litellm_provider": "bedrock",
+        "mode": "chat",
+        "supports_function_calling": true
     }
 }


### PR DESCRIPTION
Prices updated:
* gemini-1.5-pro
* gemini-1.5-pro-001
* gemini-1.5-pro-002
* gemini-1.5-flash
* gemini-1.5-flash-001
* gemini-1.5-flash-002
* gemini-1.5-flash-preview-0514
* vertex_ai/meta/llama-3.2-90b-vision-instruct-maas

New models added:
* azure_ai/mistral-large-2407
* azure_ai/ministral-3b
* azure_ai/Llama-3.2-11B-Vision-Instruct
* azure_ai/Llama-3.2-90B-Vision-Instruct
* azure_ai/Phi-3.5-mini-instruct
* azure_ai/Phi-3.5-vision-instruct
* azure_ai/Phi-3.5-MoE-instruct
* azure_ai/Phi-3-mini-4k-instruct
* azure_ai/Phi-3-mini-128k-instruct
* azure_ai/Phi-3-small-8k-instruct
* azure_ai/Phi-3-small-128k-instruct
* azure_ai/Phi-3-medium-4k-instruct
* azure_ai/Phi-3-medium-128k-instruct
* xai/grok-beta
* claude-3-5-haiku-20241022
* vertex_ai/claude-3-5-haiku@20241022
* openrouter/anthropic/claude-3-5-haiku
* openrouter/anthropic/claude-3-5-haiku-20241022
* anthropic.claude-3-5-haiku-20241022-v1:0
* us.anthropic.claude-3-5-haiku-20241022-v1:0
* eu.anthropic.claude-3-5-haiku-20241022-v1:0