### PR TITLE
fix: OpenAI "o" series models tokens and costs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "tiktoken>=0.7.0",
+    "tiktoken>=0.9.0",
     "aiohttp>=3.9.3",
     "anthropic>=0.34.0"
 ]

--- a/tokencost/costs.py
+++ b/tokencost/costs.py
@@ -91,7 +91,7 @@ def count_message_tokens(messages: List[Dict[str, str]], model: str) -> int:
         "gpt-4-turbo-2024-04-09",
         "gpt-4o",
         "gpt-4o-2024-05-13",
-    }:
+    } or model.startswith("o"):
         tokens_per_message = 3
         tokens_per_name = 1
     elif model == "gpt-3.5-turbo-0301":


### PR DESCRIPTION
Minor fix for tokenizing the "o" series models and calculating their costs.

Resolves false positive `KeyError` when model does not implement `num_tokens_from_messages()`.