### PR TITLE
Set 10-second timeout when requesting model prices

### DIFF
--- a/tokencost/constants.py
+++ b/tokencost/constants.py
@@ -34,7 +34,8 @@ async def fetch_costs():
     Raises:
         Exception: If the request fails.
     """
-    async with aiohttp.ClientSession(trust_env=True) as session:
+    timeout = aiohttp.ClientTimeout(total=10)  # 10 seconds timeout
+    async with aiohttp.ClientSession(trust_env=True, timeout=timeout) as session:
         async with session.get(PRICES_URL) as response:
             if response.status == 200:
                 return await response.json(content_type=None)


### PR DESCRIPTION
otherwise on a very slow connection, like the in-flight wifi I'm on, the request can hang indefinitely.

This causes it to give up after 10 seconds and fall back to using static prices.  