### PR TITLE
Restore and sync pricing table in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,18 @@ For Anthropic models above version 3 (i.e. Sonnet 3.5, Haiku 3.5, and Opus 3), w
 
 ## Cost table
 Units denominated in USD. All prices can be located [here](pricing_table.md).
+
+| Model Name                                                            | Prompt Cost (USD) per 1M tokens   | Completion Cost (USD) per 1M tokens   | Max Prompt Tokens   |   Max Output Tokens |
+|:----------------------------------------------------------------------|:----------------------------------|:--------------------------------------|:--------------------|--------------------:|
+| gpt-4                                                                 | $30                               | $60                                   | 8192                |            4096     |
+| gpt-4o                                                                | $2.5                              | $10                                   | 128,000             |           16384     |
+| gpt-4o-audio-preview                                                  | $2.5                              | $10                                   | 128,000             |           16384     |
+| gpt-4o-audio-preview-2024-10-01                                       | $2.5                              | $10                                   | 128,000             |           16384     |
+| gpt-4o-mini                                                           | $0.15                             | $0.6                                  | 128,000             |           16384     |
+| gpt-4o-mini-2024-07-18                                                | $0.15                             | $0.6                                  | 128,000             |           16384     |
+| o1-mini                                                               | $1.1                              | $4.4                                  | 128,000             |           65536     |
+| o1-mini-2024-09-12                                                    | $3                                | $12                                   | 128,000             |           65536     |
+| o1-preview                                                            | $15                               | $60                                   | 128,000             |           32768     |
+| o1-preview-2024-09-12                                                 | $15                               | $60                                   | 128,000             |           32768     |
+
+**Note:** This table shows a subset of available models. For the complete list of models and pricing, see [pricing_table.md](pricing_table.md).

--- a/update_prices.py
+++ b/update_prices.py
@@ -2,6 +2,7 @@ import pandas as pd
 import tokencost
 from decimal import Decimal
 import json
+import re
 
 # Update model_prices.json with the latest costs from the LiteLLM cost tracker
 print("Fetching latest prices...")
@@ -122,3 +123,26 @@ with open("pricing_table.md", "w") as f:
     f.write(table_md)
 
 print("Pricing table updated in pricing_table.md")
+
+# Read the README.md file
+with open("README.md", "r") as f:
+    readme_content = f.read()
+
+# Find and replace just the table in the README, preserving the header text
+# The regex pattern matches a markdown table starting with the "Model Name" header
+# and ending before the "Note:" line
+table_pattern = r"(?s)\| Model Name.*?(?=\n\n\*\*Note:\*\*)"
+
+# Get a subset of the table (first 10 rows) for the README
+table_lines = table_md.split('\n')
+subset_table = '\n'.join(table_lines[:12])  # Header + separator + first 10 data rows
+
+table_replacement = subset_table
+
+updated_readme = re.sub(table_pattern, table_replacement, readme_content, flags=re.DOTALL)
+
+# Write the updated README
+with open("README.md", "w") as f:
+    f.write(updated_readme)
+
+print("README.md updated with the latest pricing table")


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Restores the pricing table to `README.md` and updates `update_prices.py` to automatically manage its content.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->

---
<a href="https://cursor.com/background-agent?bcId=bc-17f732f2-40a6-46a3-819f-62dc14f05bdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-17f732f2-40a6-46a3-819f-62dc14f05bdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>