### PR TITLE
Add aws bedrock model cost tracking

### DIFF
--- a/tokencost/__init__.py
+++ b/tokencost/__init__.py
@@ -5,5 +5,7 @@ from .costs import (
     calculate_prompt_cost,
     calculate_all_costs_and_tokens,
     calculate_cost_by_tokens,
+    configure_model,
+    register_model_pattern,
 )
 from .constants import TOKEN_COSTS_STATIC, TOKEN_COSTS, update_token_costs, refresh_prices


### PR DESCRIPTION
Enable cost tracking for AWS Bedrock models and allow custom pricing via new APIs to address unrecognized model warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-9444332f-f521-448e-9a73-c01e477df7af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9444332f-f521-448e-9a73-c01e477df7af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

